### PR TITLE
Spike/330/fetch facebook post data

### DIFF
--- a/back-end/app.js
+++ b/back-end/app.js
@@ -258,7 +258,6 @@ app.get("/get_me", async (req, res) => {
 })
 
 
-
 app.get('/get_facebook', async (req, res) => {
     const accessToken = req.query.accessToken
     console.log("accessToken:",accessToken)
@@ -267,6 +266,33 @@ app.get('/get_facebook', async (req, res) => {
     let post_data=''
     const my_username = req.user.username
 
+    const save_posts = async () => {
+        console.log("start")
+        await UserInfo.findOne({user_name: my_username}, async(err, UserInfos)=>{
+            try {
+                post_data.forEach((item)=>{
+                    if('message' in item){
+                        console.log("post data for each", post_data)
+                        UserInfos.post_data.unshift({
+                            content:item.message,
+                            source:"Facebook",
+                            senttime:item.created_time,
+                            contentimg:" ",
+                        })
+                        UserInfos.post_number++
+                    }
+                })
+                await UserInfos.save(function(saveErr, saveUserInfos) {
+                    if(err){
+                        console.log('error saving post')
+                    }
+                });   
+            } catch(e){
+                console.log(e)
+            }
+        })
+    }
+    
     await request(
         `https://graph.facebook.com/${process.env.GRAPH_API_VERSION}/oauth/access_token?grant_type=fb_exchange_token&client_id=${process.env.APP_ID}&client_secret=${process.env.APP_SECRET}&fb_exchange_token=${accessToken}`,
 
@@ -313,33 +339,7 @@ app.get('/get_facebook', async (req, res) => {
                                         post_data=res2.data
                                         console.log("posts:",post_data)
                                         if (res2.data){
-                                            console.log("start")
-                                            await UserInfo.findOne({user_name: my_username}, async(err, UserInfos)=>{
-                                                try {
-                                                    post_data.forEach((item)=>{
-                                                        if('message' in item){
-                                                            console.log("post data for each", post_data)
-                                                            UserInfos.post_data.unshift({
-                                                                content:item.message,
-                                                                source:"Facebook",
-                                                                senttime:item.created_time,
-                                                                contentimg:" ",
-                                                            })
-                                                            UserInfos.post_number++
-
-                                                        }
-                                                        
-                                                    })
-                                                    await UserInfos.save(function(saveErr, saveUserInfos) {
-                                                        if(err){
-                                                            console.log('error saving post')
-                                                        }
-                                                    });   
-                                                } catch(e){
-                                                    console.log(e)
-                                                }
-                                            })
-
+                                            save_posts()
                                         }
                                     }
                                 }

--- a/back-end/app.js
+++ b/back-end/app.js
@@ -266,6 +266,7 @@ app.get('/get_facebook', async (req, res) => {
     let long_lived_token=''
     let post_data=''
     const my_username = req.user.username
+
     await request(
         `https://graph.facebook.com/${process.env.GRAPH_API_VERSION}/oauth/access_token?grant_type=fb_exchange_token&client_id=${process.env.APP_ID}&client_secret=${process.env.APP_SECRET}&fb_exchange_token=${accessToken}`,
 
@@ -307,9 +308,39 @@ app.get('/get_facebook', async (req, res) => {
                                         console.log("error")
                                     }
                                     else{
-                                        console.log("get posts:",body)
-                                        const res2=JSON.parse(body)
+                                        //console.log("get posts:",body)
+                                        const res2=await JSON.parse(body)
                                         post_data=res2.data
+                                        console.log("posts:",post_data)
+                                        if (res2.data){
+                                            console.log("start")
+                                            await UserInfo.findOne({user_name: my_username}, async(err, UserInfos)=>{
+                                                try {
+                                                    post_data.forEach((item)=>{
+                                                        if('message' in item){
+                                                            console.log("post data for each", post_data)
+                                                            UserInfos.post_data.unshift({
+                                                                content:item.message,
+                                                                source:"Facebook",
+                                                                senttime:item.created_time,
+                                                                contentimg:" ",
+                                                            })
+                                                            UserInfos.post_number++
+
+                                                        }
+                                                        
+                                                    })
+                                                    await UserInfos.save(function(saveErr, saveUserInfos) {
+                                                        if(err){
+                                                            console.log('error saving post')
+                                                        }
+                                                    });   
+                                                } catch(e){
+                                                    console.log(e)
+                                                }
+                                            })
+
+                                        }
                                     }
                                 }
                             )

--- a/back-end/app.js
+++ b/back-end/app.js
@@ -265,7 +265,7 @@ app.get('/get_facebook', async (req, res) => {
     let userID=''
     let long_lived_token=''
     let post_data=''
-
+    const my_username = req.user.username
     await request(
         `https://graph.facebook.com/${process.env.GRAPH_API_VERSION}/oauth/access_token?grant_type=fb_exchange_token&client_id=${process.env.APP_ID}&client_secret=${process.env.APP_SECRET}&fb_exchange_token=${accessToken}`,
 
@@ -302,7 +302,7 @@ app.get('/get_facebook', async (req, res) => {
 
                             await request(
                                 `https://graph.facebook.com/${process.env.GRAPH_API_VERSION}/${userID}/feed?fields=id,created_time,message,object_id,permalink_url&access_token=${long_lived_token}`,
-                                function (error, response, body) {
+                                async function (error, response, body) {
                                     if(error){
                                         console.log("error")
                                     }

--- a/back-end/app.js
+++ b/back-end/app.js
@@ -264,6 +264,7 @@ app.get('/get_facebook', async (req, res) => {
     console.log("accessToken:",accessToken)
     let userID=''
     let long_lived_token=''
+    let post_data=''
 
     await request(
         `https://graph.facebook.com/${process.env.GRAPH_API_VERSION}/oauth/access_token?grant_type=fb_exchange_token&client_id=${process.env.APP_ID}&client_secret=${process.env.APP_SECRET}&fb_exchange_token=${accessToken}`,
@@ -300,13 +301,15 @@ app.get('/get_facebook', async (req, res) => {
                             )
 
                             await request(
-                                `https://graph.facebook.com/${process.env.GRAPH_API_VERSION}/${userID}/feed?access_token=${long_lived_token}`,
+                                `https://graph.facebook.com/${process.env.GRAPH_API_VERSION}/${userID}/feed?fields=id,created_time,message,object_id,permalink_url&access_token=${long_lived_token}`,
                                 function (error, response, body) {
                                     if(error){
                                         console.log("error")
                                     }
                                     else{
                                         console.log("get posts:",body)
+                                        const res2=JSON.parse(body)
+                                        post_data=res2.data
                                     }
                                 }
                             )
@@ -316,18 +319,6 @@ app.get('/get_facebook', async (req, res) => {
             }
         }
     )
-   /* await request(
-        `https://graph.facebook.com/${process.env.GRAPH_API_VERSION}/${userID}/permissions?access_token=${long_lived_token}`,
-        function (error, response, body) {
-            if(error){
-                console.log("error")
-            }
-            else{
-                console.log(`https://graph.facebook.com/${process.env.GRAPH_API_VERSION}/${userID}/permissions?access_token=${long_lived_token}`)
-                console.log("get permissions lists allowed:",body)
-            }
-        }
-    )*/
 })
 
 

--- a/front-end/src/me/Me.js
+++ b/front-end/src/me/Me.js
@@ -71,8 +71,8 @@ const Me = (props) => {
                 console.log('User already logged in Facebook and autenticated')
                 SetClicked_unconnected_social_media('Facebook')
             } else {
-                console.log('user not logged in FB')
-                SetClicked_linked_social_media('Facebook')
+                //console.log('user not logged in FB')
+                //SetClicked_linked_social_media('Facebook')
             }
         })
     }

--- a/front-end/src/me/Me.js
+++ b/front-end/src/me/Me.js
@@ -6,7 +6,6 @@ import { Gear } from 'react-bootstrap-icons'
 import { ClockHistory } from 'react-bootstrap-icons'
 import { TextParagraph } from 'react-bootstrap-icons'
 import { HeartFill } from 'react-bootstrap-icons'
-
 import axios from 'axios'
 import Linked_platform_connect from './Linked_platform_connect'
 import Unconnected_social_media from './Unconnected_social_media'
@@ -65,6 +64,7 @@ const Me = (props) => {
     }
     const LoginStatus_fb = async () => {
         setUpFacebookSDK()
+
         window.FB.getLoginStatus(function (response) {
             console.log(response)
             if (response.status === 'connected') {

--- a/front-end/src/me/Me.js
+++ b/front-end/src/me/Me.js
@@ -46,8 +46,8 @@ const Me = (props) => {
     }
     const handleClick_Unconnected = (response) => {
         let elements = document.getElementsByTagName('BUTTON')
-        console.log('elements of BUTTON:', elements)
-        console.log('elements.length:', elements.length)
+        //console.log('elements of BUTTON:', elements)
+        //console.log('elements.length:', elements.length)
 
         //deal with unconnected social media
         for (let i = response.data.linked_social_media.length; i < elements.length; i++) {
@@ -64,6 +64,7 @@ const Me = (props) => {
         }
     }
     const LoginStatus_fb = async () => {
+        setUpFacebookSDK()
         window.FB.getLoginStatus(function (response) {
             console.log(response)
             if (response.status === 'connected') {


### PR DESCRIPTION
- After the user login to Facebook, all the posts the user had in his Facebook account are saved in the database to save Facebook API call limit and shown on the `my_profile` page. (only post_text and post_create_date are shown now. post_image will be added later.)
- Now refresh will not disconnect Facebook to save API call limit, even though the status is changed to `unkown` in front-end. (now I use the `long-lived-token` which is valid for 90 days to make calls to Facebook in behalf of the user.) 
- `Unconnect facebook`button will be implemented later.
- Synchronize with Facebook post data will be implemented later. 


